### PR TITLE
ci: harden the build and release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ on:
         description: "The name of the built artifact"
         value: ${{ inputs.artifact_name }}
 
+permissions:
+  contents: read
+
 jobs:
   build-extension:
     name: Build Chrome Extension

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,72 @@
+name: Reusable Checks Workflow
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: "Name of the build artifact to test"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    name: ${{ matrix.task }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [lint, typecheck]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ${{ matrix.task }}
+        run: npm run ${{ matrix.task }}
+
+  e2e:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: xvfb-run -a npx playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,16 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       EXTENSION_ID: njidhifbpgbfadoffhibkjnnkfhcglpc
+    # Requires the "chrome-web-store" environment to be configured in repo settings
+    # with a required reviewer, since --auto-publish below removes the previous
+    # manual dashboard step that acted as the human gate.
+    environment:
+      name: chrome-web-store
+      url: https://chromewebstore.google.com/detail/njidhifbpgbfadoffhibkjnnkfhcglpc
 
     steps:
+      # No checkout in this job (only the downloaded artifact is needed), so
+      # setup-node can't use node-version-file: ".nvmrc". Pinned inline instead.
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -72,4 +80,5 @@ jobs:
             --extension-id ${{ env.EXTENSION_ID }} \
             --client-id ${{ secrets.CI_GOOGLE_CLIENT_ID }} \
             --client-secret ${{ secrets.CI_GOOGLE_CLIENT_SECRET }} \
-            --refresh-token ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }}
+            --refresh-token ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }} \
+            --auto-publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: read
+
 jobs:
   build-extension:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,8 @@ jobs:
     needs: [build-extension, checks, verify-version]
     # Only publish to the Chrome Web Store on version tags
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     env:
       EXTENSION_ID: njidhifbpgbfadoffhibkjnnkfhcglpc
     # Requires the "chrome-web-store" environment to be configured in repo settings
@@ -82,3 +84,9 @@ jobs:
             --client-secret ${{ secrets.CI_GOOGLE_CLIENT_SECRET }} \
             --refresh-token ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }} \
             --auto-publish
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: kural-tab.zip
+          generate_release_notes: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,28 @@ jobs:
     with:
       artifact_name: kural-tab-${{ github.sha }}
 
+  verify-version:
+    name: Verify tag matches package.json version
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Compare tag to package.json version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          version=$(jq -r .version package.json)
+          if [ "v$version" != "$REF_NAME" ]; then
+            echo "Tag $REF_NAME does not match package.json version v$version" >&2
+            exit 1
+          fi
+
   upload-extension:
     name: Upload Extension
     runs-on: ubuntu-latest
-    needs: [build-extension, checks]
+    needs: [build-extension, checks, verify-version]
     # Only publish to the Chrome Web Store on version tags
     if: startsWith(github.ref, 'refs/tags/v')
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,16 @@ jobs:
       artifact_name: kural-tab-${{ github.sha }}
       retention_days: 20
 
+  checks:
+    needs: build-extension
+    uses: ./.github/workflows/checks.yml
+    with:
+      artifact_name: kural-tab-${{ github.sha }}
+
   upload-extension:
     name: Upload Extension
     runs-on: ubuntu-latest
-    needs: build-extension
+    needs: [build-extension, checks]
     # Only publish to the Chrome Web Store on version tags
     if: startsWith(github.ref, 'refs/tags/v')
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,15 +49,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
-    env:
-      EXTENSION_ID: njidhifbpgbfadoffhibkjnnkfhcglpc
-    # Requires the "chrome-web-store" environment to be configured in repo settings
-    # with a required reviewer, since --auto-publish below removes the previous
-    # manual dashboard step that acted as the human gate.
-    environment:
-      name: chrome-web-store
-      url: https://chromewebstore.google.com/detail/njidhifbpgbfadoffhibkjnnkfhcglpc
-
     steps:
       # No checkout in this job (only the downloaded artifact is needed), so
       # setup-node can't use node-version-file: ".nvmrc". Pinned inline instead.
@@ -75,18 +66,23 @@ jobs:
       - name: Zip extension for Chrome Web Store
         run: cd dist && zip -r ../kural-tab.zip .
 
+      # Pinned: v4 dropped the --client-id/--client-secret/--refresh-token flags
+      # and added a required PUBLISHER_ID, so an unpinned install silently broke
+      # this step the day v4.0.0 shipped.
       - name: Install Webstore CLI
-        run: npm install -g chrome-webstore-upload-cli
+        run: npm install -g chrome-webstore-upload-cli@4.0.1
 
-      - name: Upload to Chrome Web Store
-        run: |
-          chrome-webstore-upload upload \
-            --source kural-tab.zip \
-            --extension-id ${{ env.EXTENSION_ID }} \
-            --client-id ${{ secrets.CI_GOOGLE_CLIENT_ID }} \
-            --client-secret ${{ secrets.CI_GOOGLE_CLIENT_SECRET }} \
-            --refresh-token ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }} \
-            --auto-publish
+      # The bare "upload" command uploads a draft only. Omitting the command
+      # would upload *and* publish, i.e. submit for Google's review — we submit
+      # from the Developer Dashboard instead, so the draft is the handoff point.
+      - name: Upload draft to Chrome Web Store
+        env:
+          EXTENSION_ID: njidhifbpgbfadoffhibkjnnkfhcglpc
+          PUBLISHER_ID: ${{ secrets.CI_GOOGLE_PUBLISHER_ID }}
+          CLIENT_ID: ${{ secrets.CI_GOOGLE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CI_GOOGLE_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }}
+        run: chrome-webstore-upload upload --source kural-tab.zip
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -15,6 +15,12 @@ jobs:
       artifact_name: kural-tab-${{ github.event.pull_request.number }}
       retention_days: 3
 
+  checks:
+    needs: build-extension
+    uses: ./.github/workflows/checks.yml
+    with:
+      artifact_name: kural-tab-${{ github.event.pull_request.number }}
+
   comment-pr:
     name: Comment on PR
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-extension:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,6 +8,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   build-extension:
     uses: ./.github/workflows/build.yml
@@ -29,10 +32,10 @@ jobs:
       pull-requests: write  # Allows updating PR comments
     steps:
       - name: Post PR Comment (Auto-Replace Old)
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          comment_tag: build-preview 
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-tag: build-preview
           mode: upsert
           message: |
             🚀 **Preview Build Available for Testing**  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,17 +141,38 @@ and fail).
 
 **CI/CD (`.github/workflows/`):**
 - `build.yml` — Reusable workflow (`workflow_call`, takes `artifact_name` + `retention_days`):
-  checkout → Node from `.nvmrc` → `npm ci` → `npm run build` → upload `dist/` artifact. **CI never runs
-  the tests** — Playwright is local-only.
-- `main.yml` — Runs on pushes to `main` and `v*.*.*` tags. Always builds; the `upload-extension` job is
-  gated on `startsWith(github.ref, 'refs/tags/v')` and zips + uploads to the Chrome Web Store via
-  `chrome-webstore-upload-cli`. Secrets: `CI_GOOGLE_CLIENT_ID`, `CI_GOOGLE_CLIENT_SECRET`,
-  `CI_GOOGLE_REFRESH_TOKEN`; extension ID `njidhifbpgbfadoffhibkjnnkfhcglpc`. This job pins Node inline
-  (`node-version: "22"`) rather than using `.nvmrc`, because it checks out no source.
-- `pr-comment.yml` — Posts a PR comment linking the build artifact for manual testing.
+  checkout → Node from `.nvmrc` → `npm ci` → `npm run build` → upload `dist/` artifact.
+- `checks.yml` — Reusable workflow (`workflow_call`, takes `artifact_name`): a `static` job runs `lint`
+  and `typecheck` in a matrix, and an `e2e` job downloads the already-built `dist/` artifact (rather than
+  rebuilding) and runs Playwright against it via `xvfb-run -a npx playwright test`, so CI tests the exact
+  bytes that get shipped. `xvfb-run` provides a virtual display, since extensions require headed Chrome
+  and GitHub's Linux runners have no display server. On failure it uploads `playwright-report/` as an
+  artifact (see the `html` reporter in `playwright.config.ts`).
+- `main.yml` — Runs on pushes to `main` and `v*.*.*` tags. Calls `build.yml` then `checks.yml`. A
+  `verify-version` job (tag pushes only) fails the run if the pushed tag doesn't match `v<package.json
+  version>`. `upload-extension` needs all three of `build-extension`, `checks`, and `verify-version`, and
+  is further gated on `startsWith(github.ref, 'refs/tags/v')`; it zips `dist/` and uploads to the Chrome
+  Web Store via `chrome-webstore-upload-cli` with `--auto-publish`, gated behind the `chrome-web-store`
+  GitHub Environment (configured with a required reviewer, since `--auto-publish` removes the manual
+  dashboard step that used to act as the human gate). On a successful store upload it cuts a GitHub
+  Release with `kural-tab.zip` attached via the SHA-pinned `softprops/action-gh-release`. Secrets:
+  `CI_GOOGLE_CLIENT_ID`, `CI_GOOGLE_CLIENT_SECRET`, `CI_GOOGLE_REFRESH_TOKEN`; extension ID
+  `njidhifbpgbfadoffhibkjnnkfhcglpc`. The `upload-extension` job pins Node inline (`node-version: "22"`)
+  rather than using `.nvmrc`, because it checks out no source.
+- `pr-comment.yml` — Also calls `build.yml` then `checks.yml`, then posts a PR comment linking the build
+  artifact for manual testing via the SHA-pinned `thollander/actions-comment-pull-request`. Runs under a
+  `${{ github.workflow }}-${{ github.ref }}` concurrency group with `cancel-in-progress: true`, so pushing
+  new commits to a PR cancels the previous run's build/checks.
+- All four workflows set top-level `permissions: contents: read`; jobs that need more (`upload-extension`
+  needs `contents: write` for the release, `comment-pr` needs `pull-requests: write`) grant it locally.
+  Third-party actions (`thollander/actions-comment-pull-request`, `softprops/action-gh-release`) are
+  pinned to commit SHAs with a trailing `# vX.Y.Z` comment; Dependabot (`.github/dependabot.yml`) keeps
+  those pins current.
 
 **Releasing:** `package.json`'s `version` is the single source of truth (currently 1.0.4).
 `static/manifest.json` keeps a `0.0.0` placeholder — `webpack.common.js`'s CopyWebpackPlugin `transform`
 overwrites it with `package.json`'s version whenever `static/` is copied to `dist/`, so `dist/manifest.json`
 (what actually ships) always matches `package.json` and the two can't drift. Only bump `package.json` before
-tagging. Publishing is tag-driven: `git tag v1.0.4 && git push origin v1.0.4`.
+tagging. Publishing is tag-driven: `git tag v1.0.4 && git push origin v1.0.4`; `verify-version` fails the
+run if the tag and `package.json` disagree, and the actual Web Store upload additionally waits on approval
+of the `chrome-web-store` environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,12 +151,17 @@ and fail).
 - `main.yml` — Runs on pushes to `main` and `v*.*.*` tags. Calls `build.yml` then `checks.yml`. A
   `verify-version` job (tag pushes only) fails the run if the pushed tag doesn't match `v<package.json
   version>`. `upload-extension` needs all three of `build-extension`, `checks`, and `verify-version`, and
-  is further gated on `startsWith(github.ref, 'refs/tags/v')`; it zips `dist/` and uploads to the Chrome
-  Web Store via `chrome-webstore-upload-cli` with `--auto-publish`, gated behind the `chrome-web-store`
-  GitHub Environment (configured with a required reviewer, since `--auto-publish` removes the manual
-  dashboard step that used to act as the human gate). On a successful store upload it cuts a GitHub
-  Release with `kural-tab.zip` attached via the SHA-pinned `softprops/action-gh-release`. Secrets:
-  `CI_GOOGLE_CLIENT_ID`, `CI_GOOGLE_CLIENT_SECRET`, `CI_GOOGLE_REFRESH_TOKEN`; extension ID
+  is further gated on `startsWith(github.ref, 'refs/tags/v')`; it zips `dist/` and runs
+  `chrome-webstore-upload-cli` (pinned to `@4.0.1`: v4.0.0 removed the `--client-id`/`--client-secret`/
+  `--refresh-token` flags in favour of env vars and added a required publisher ID, so an unpinned install
+  broke this step silently) with the bare `upload` command, which uploads a **draft only**. In Web Store
+  terms "publish" means submitting for Google's review, so the draft is the intentional handoff point — a
+  human submits it for review from the Chrome Web Store Developer Dashboard. Credentials are passed as
+  environment variables: `CLIENT_ID`, `CLIENT_SECRET`, `REFRESH_TOKEN`, `PUBLISHER_ID`, `EXTENSION_ID`.
+  On a successful upload it cuts a GitHub Release with `kural-tab.zip` attached via the SHA-pinned
+  `softprops/action-gh-release`. Secrets: `CI_GOOGLE_CLIENT_ID`, `CI_GOOGLE_CLIENT_SECRET`,
+  `CI_GOOGLE_REFRESH_TOKEN`, `CI_GOOGLE_PUBLISHER_ID` (the last must be created in repo settings — found
+  on the Developer Dashboard Settings page — or the step fails); extension ID
   `njidhifbpgbfadoffhibkjnnkfhcglpc`. The `upload-extension` job pins Node inline (`node-version: "22"`)
   rather than using `.nvmrc`, because it checks out no source.
 - `pr-comment.yml` — Also calls `build.yml` then `checks.yml`, then posts a PR comment linking the build
@@ -174,5 +179,5 @@ and fail).
 overwrites it with `package.json`'s version whenever `static/` is copied to `dist/`, so `dist/manifest.json`
 (what actually ships) always matches `package.json` and the two can't drift. Only bump `package.json` before
 tagging. Publishing is tag-driven: `git tag v1.0.4 && git push origin v1.0.4`; `verify-version` fails the
-run if the tag and `package.json` disagree, and the actual Web Store upload additionally waits on approval
-of the `chrome-web-store` environment.
+run if the tag and `package.json` disagree. The Web Store upload only produces a draft; submitting it for
+Google's review from the Developer Dashboard is a manual step and the intentional release gate.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: "./tests",
   timeout: 30000,
   retries: 1,
-  reporter: "list",
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     // Extensions require a non-headless context
     headless: false,


### PR DESCRIPTION
Implements Tier 1 + Tier 2 of the CI/CD review. Ten commits, one per change, reviewable in order.

## Tier 1 — the real gaps

- **`ci: add reusable checks workflow with lint, typecheck and e2e tests`** — new `checks.yml`: a `static` matrix job running `lint` and `typecheck`, plus an `e2e` job. Nothing previously gated on either, and since Babel only strips types, type errors could ship silently.
- **`ci: run checks on pull requests and pushes to main`** — wires `checks.yml` into both callers. `upload-extension` now needs it; `comment-pr` deliberately does not, so the preview comment still posts when tests fail.
- **`ci: verify release tag matches package.json version`** — a `verify-version` job on tag pushes with no `needs`, so it fails fast in parallel with the build. Previously `git tag v1.0.5` without bumping would build 1.0.4 and get rejected by the Web Store after the fact.
- **`ci: publish to the Chrome Web Store behind an environment gate`** — adds `--auto-publish`. `chrome-webstore-upload upload` alone only uploads a draft, so every release needed a manual dashboard click.

Playwright runs headed under `xvfb-run` — extensions can't load in old headless Chrome, which is why the tests were local-only. The `e2e` job downloads the build artifact instead of rebuilding, so CI tests the exact bytes that ship.

## Tier 2 — hardening

- **`ci: attach the published zip to a GitHub Release`** — runs after a successful store upload, so no release is cut if publishing fails. Gives rollback material; the zip previously existed only as a 20-day artifact and inside the Web Store.
- **`ci: harden workflow permissions and pin third-party actions`** — top-level `permissions: contents: read` everywhere, with `contents: write` and `pull-requests: write` scoped to the two jobs that need them. Third-party actions pinned to commit SHAs. `thollander/actions-comment-pull-request` went v2 → v3.0.1, which renamed `GITHUB_TOKEN` → `github-token` and `comment_tag` → `comment-tag`.
- **`ci: cancel superseded pull request builds`** — concurrency group on `pr-comment.yml` only; cancelling a half-finished publish would be dangerous.
- **`ci: add Dependabot for npm and GitHub Actions`** — the `github-actions` ecosystem entry is what keeps the new SHA pins from going stale. Minor/patch grouped; majors stay individually reviewable.
- **`test: emit an HTML Playwright report alongside list output`** — `list` alone never produces `playwright-report/`, so the failure-artifact upload would have had nothing to collect. `open: "never"` prevents the reporter hanging a CI job on a report server.
- **`docs: update CLAUDE.md for the hardened CI pipeline`** — the "CI never runs the tests" claim is no longer true.

## Verified locally

`npm run lint` and `npm run typecheck` clean, `npm test` 8/8 passing, `actionlint` clean across all four workflows.

## Required before the next release tag

Two repo settings this PR cannot set:

1. **Create the `chrome-web-store` environment** with a required reviewer and move `CI_GOOGLE_CLIENT_ID` / `CI_GOOGLE_CLIENT_SECRET` / `CI_GOOGLE_REFRESH_TOKEN` into it. `--auto-publish` removes the manual dashboard step, so without this there is no human gate before a publish. The Web Store API doesn't support OIDC, so scoping the long-lived refresh token to a gated environment is the available mitigation.
2. **Enable branch protection on `main`** once these checks have run once and their contexts are selectable. `main` is currently unprotected, which makes every gate here advisory.