### PR TITLE
chore: bump version to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kural-tab",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kural-tab",
-      "version": "1.0.0",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kural-tab",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "New tab extension",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Version bump only — no functional change. Needed as its own PR now that branch protection blocks direct pushes to `main`.

`package.json` 1.0.4 → 1.0.5 (plus the matching `package-lock.json` entries). `static/manifest.json` keeps its `0.0.0` placeholder; CopyWebpackPlugin rewrites it at build time, so `dist/manifest.json` picks this up automatically.

## What this releases

Everything on `main` since 1.0.4:

- **Noto Sans Tamil is self-hosted** rather than fetched from Google Fonts — the only user-visible change, and it removes a third-party request from the new tab page.
- Duplicate `static/style.css` consolidated into `src/styles/style.css` (they had silently drifted).
- Dead code removed (`src/content.ts`, unused constants in `models.ts`).
- Build and release pipeline hardened (#24).

Patch-level: no behaviour, UI, or manifest permission changes.

## Next

Once this merges, `v1.0.5` gets tagged and pushed, which triggers `verify-version` → build → checks → Web Store **draft** upload → GitHub Release. Nothing reaches users until the draft is submitted for review from the Developer Dashboard.

This will also be the first real exercise of the fixed upload step — the credentials fix and the `@4.0.1` pin have only been verified against the CLI's source so far, never against the live API.