### PR TITLE
chore: CI follow-ups — Dependabot-tracked CLI, release notes config, cleanups

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+        - fix
+    - title: CI & Build
+      labels:
+        - ci
+        - build
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      # No checkout in this job (only the downloaded artifact is needed), so
-      # setup-node can't use node-version-file: ".nvmrc". Pinned inline instead.
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -66,12 +71,10 @@ jobs:
       - name: Zip extension for Chrome Web Store
         run: cd dist && zip -r ../kural-tab.zip .
 
-      # Pinned: v4 dropped the --client-id/--client-secret/--refresh-token flags
-      # and added a required PUBLISHER_ID, so an unpinned install silently broke
-      # this step the day v4.0.0 shipped.
-      - name: Install Webstore CLI
-        run: npm install -g chrome-webstore-upload-cli@4.0.1
-
+      # chrome-webstore-upload-cli is pinned to an exact version (no caret) in
+      # devDependencies: v4 dropped the --client-id/--client-secret/--refresh-token
+      # flags and added a required PUBLISHER_ID, so an unpinned install silently
+      # broke this step the day v4.0.0 shipped.
       # The bare "upload" command uploads a draft only. Omitting the command
       # would upload *and* publish, i.e. submit for Google's review — we submit
       # from the Developer Dashboard instead, so the draft is the handoff point.
@@ -82,7 +85,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CI_GOOGLE_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CI_GOOGLE_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }}
-        run: chrome-webstore-upload upload --source kural-tab.zip
+        run: npx chrome-webstore-upload upload --source kural-tab.zip
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ npm run typecheck  # tsc --noEmit (webpack strips types via Babel and never type
 Node version is pinned to 22.16.0 via `.nvmrc`; use `nvm use` before running commands.
 
 `eslint.config.mjs` is a flat config using `@eslint/js` recommended, `typescript-eslint`
-`recommendedTypeChecked`, and `eslint-plugin-react`. There is **no format script** — Prettier is in
-`devDependencies` but isn't wired up.
+`recommendedTypeChecked`, and `eslint-plugin-react`. There is **no formatter** — Prettier was removed
+because it was never wired up (no script, no config file, no ESLint integration).
 
 Because Babel only strips types, **`npm run build` succeeds on code with type errors**. Run
 `npm run typecheck` explicitly after changing types.
@@ -42,7 +42,6 @@ Webpack 5 + Babel + TypeScript.
   it is the new tab page, not a content script.
 - `background` → `src/background.ts` → `dist/background.js` — service worker; on icon click opens a new
   tab and injects `content.js` into it.
-- `src/content.ts` is **dead code** — nothing imports it and it isn't a webpack entry. Ignore it.
 - `static/manifest.json` — Manifest V3; declares `chrome_url_overrides.newtab`, storage + scripting permissions.
 
 **State management via React Context:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.19",
         "babel-loader": "^9.1.3",
+        "chrome-webstore-upload-cli": "4.0.1",
         "copy-webpack-plugin": "^13.0.0",
         "css-loader": "^6.10.0",
         "eslint": "^9.26.0",
@@ -37,6 +38,9 @@
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1",
         "webpack-merge": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3097,6 +3101,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3233,6 +3247,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/chrome-webstore-upload": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chrome-webstore-upload/-/chrome-webstore-upload-6.0.0.tgz",
+      "integrity": "sha512-wUPi8iwR2KPPPytHY8rstA5tbcLp2r8fMYnqMUIgci1q1A6QFYiyeiyG/aqAj35PzNuCTpZseD1VZ9y1b/Fkmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "junk": "^4.0.1",
+        "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
+    },
+    "node_modules/chrome-webstore-upload-cli": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-webstore-upload-cli/-/chrome-webstore-upload-cli-4.0.1.tgz",
+      "integrity": "sha512-UGmvbEGTqNCD+W9HDEoYnZwrbp++v5WcIyVVZWxK7AxFMfxtZF/yiNtxWCcAetNg4z0m/CNhf+Qt3b0aitDEWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-webstore-upload": "^6.0.0",
+        "meow": "^12.1.1"
+      },
+      "bin": {
+        "chrome-webstore-upload": "source/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
       }
     },
     "node_modules/clone-deep": {
@@ -5714,6 +5765,19 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5825,6 +5889,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-descriptors": {
@@ -8151,6 +8228,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "eslint": "^9.26.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.0.0",
-        "prettier": "3.5.3",
         "style-loader": "^3.3.4",
         "ts-loader": "^9.5.1",
         "typescript": "^5.3.3",
@@ -6536,22 +6535,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19",
     "babel-loader": "^9.1.3",
+    "chrome-webstore-upload-cli": "4.0.1",
     "copy-webpack-plugin": "^13.0.0",
     "css-loader": "^6.10.0",
     "eslint": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint": "^9.26.0",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.0.0",
-    "prettier": "3.5.3",
     "style-loader": "^3.3.4",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.3",


### PR DESCRIPTION
Follow-ups from the pipeline review. Four commits, reviewable in order.

## 1. The Web Store CLI pin was invisible to Dependabot

`upload-extension` ran `npm install -g chrome-webstore-upload-cli@4.0.1`. That pin lives inside a shell string, and Dependabot cannot see it — the `npm` ecosystem reads manifests, the `github-actions` ecosystem reads `uses:` lines, and neither parses `run:` commands. So the pin would have gone stale silently and permanently.

We'd traded "silently breaks on upgrade" (the v4.0.0 incident) for "silently frozen forever." Better, but not the end state.

Now an exact-pinned `devDependencies` entry invoked via `npx`, so Dependabot tracks it and any bump arrives as a PR with CI green rather than as a surprise mid-release.

Side effect: the job now checks out source, so it can use `node-version-file: .nvmrc` like every other job. The inline `node-version: "22"` and its explanatory comment are gone. Checkout is ordered before the artifact download so it can't clobber `dist/`.

Cost is one `npm ci` (~20s) on release runs only.

## 2. Release notes configuration

`.github/release.yml`, which GitHub reads when generating notes for `generate_release_notes: true`. Dependabot is now live and its weekly PRs would otherwise dominate every release's notes. PRs are grouped into Features / Fixes / CI & Build / Dependencies, with a catch-all last — GitHub assigns each PR to the first matching category, so ordering matters.

## 3. Prettier removed

It was in `devDependencies` with no `format` script, no `.prettierrc` or `prettier.config.*` anywhere, and no reference from `eslint.config.mjs`. Removed rather than wired up — wiring it would mean reformatting the whole codebase in a diff that buries everything else. Worth doing deliberately later if you want a formatter.

## 4. Stale docs

`CLAUDE.md` still documented `src/content.ts` as dead code to ignore; that file was deleted in #23. The ESLint paragraph also still described Prettier as an unwired devDependency.

## Correction

I'd also flagged `"packageManager": null` in `package.json` as invalid. That was wrong — `jq '.packageManager'` prints `null` for a **missing** key, and the field was never there. Nothing to fix; no change made.

## Verified

`actionlint` clean, `npm run lint` and `npm run typecheck` clean, `package.json` valid JSON.

Note the upload step itself can't be exercised by a PR — it only runs on a `v*.*.*` tag. The `npx` switch will first execute for real on the next release. It's a low-risk change (same command, same pinned version, resolved from `node_modules` instead of a global install), but worth knowing it's unproven until then.